### PR TITLE
Dont average position if one dataset is all zeros

### DIFF
--- a/position_tools/core.py
+++ b/position_tools/core.py
@@ -15,6 +15,10 @@ def get_centroid(position1, position2):
     centroid_position : np.ndarray, shape (n_time, 2)
 
     """
+    if np.all(position1 == 0):
+        return position2
+    if np.all(position2 == 0):
+        return position1
     return (position1 + position2) / 2
 
 

--- a/position_tools/core.py
+++ b/position_tools/core.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy import interpolate
 from scipy.ndimage import gaussian_filter1d
-import warnings
+import logging
 
 def get_centroid(position1, position2):
     """Finds the midpoint of two positions.
@@ -15,11 +15,11 @@ def get_centroid(position1, position2):
     centroid_position : np.ndarray, shape (n_time, 2)
 
     """
-    if np.all(position1 == 0):
-        warnings.warn("position1 is all zeros, returning position2 as centroid")
+    if np.allclose(position1,0.0):
+        logging.warning("position1 is all zeros, returning position2 as centroid")
         return position2
-    if np.all(position2 == 0):
-        warnings.warn("position2 is all zeros, returning position1 as centroid")
+    if np.allclose(position2,0.0):
+        logging.warning("position2 is all zeros, returning position1 as centroid")
         return position1
     return (position1 + position2) / 2
 

--- a/position_tools/core.py
+++ b/position_tools/core.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy import interpolate
 from scipy.ndimage import gaussian_filter1d
-
+import warnings
 
 def get_centroid(position1, position2):
     """Finds the midpoint of two positions.
@@ -16,8 +16,10 @@ def get_centroid(position1, position2):
 
     """
     if np.all(position1 == 0):
+        warnings.warn("position1 is all zeros, returning position2 as centroid")
         return position2
     if np.all(position2 == 0):
+        warnings.warn("position2 is all zeros, returning position1 as centroid")
         return position1
     return (position1 + position2) / 2
 


### PR DESCRIPTION
- One of the two sets of data passed to `get_centroid()` is sometimes all zeros, indicating an empty set.  (see https://github.com/LorenFrankLab/spyglass/issues/829)

- In this case return the non-zero position data as the centroid